### PR TITLE
feat(oauth2): Implement OAuth2 authorization code grant

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,1 @@
+singleQuote: true

--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -1261,7 +1261,6 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -2491,8 +2490,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -2894,8 +2892,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -3913,8 +3910,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3935,14 +3931,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3957,20 +3951,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4087,8 +4078,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4100,7 +4090,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4115,7 +4104,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4123,14 +4111,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4149,7 +4135,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4230,8 +4215,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4243,7 +4227,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4329,8 +4312,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4366,7 +4348,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4386,7 +4367,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4430,14 +4410,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4446,7 +4424,6 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
-      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -4459,7 +4436,6 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
-      "optional": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -4497,8 +4473,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "get-stream": {
       "version": "3.0.0",
@@ -4692,8 +4667,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -5413,8 +5387,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -6089,7 +6062,6 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
-      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -6102,8 +6074,7 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6378,8 +6349,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
@@ -7011,7 +6981,6 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -8026,7 +7995,6 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
@@ -8038,7 +8006,6 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
-          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "pify": "^2.0.0",
@@ -8049,8 +8016,7 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -8059,7 +8025,6 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
-      "optional": true,
       "requires": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
@@ -8070,7 +8035,6 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "path-exists": "^2.0.0",
             "pinkie-promise": "^2.0.0"
@@ -8081,7 +8045,6 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
-          "optional": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
           }
@@ -9363,7 +9326,6 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-utf8": "^0.2.0"
       }
@@ -10694,7 +10656,6 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       }

--- a/angular/src/app/pages/home/home.component.html
+++ b/angular/src/app/pages/home/home.component.html
@@ -4,32 +4,54 @@
     <mat-card-content>
       <h4 mat-subheader>Basic User flow</h4>
       <mat-list>
-          <template *ngIf="isLoggedIn; then LoggedIn else LoggedOut"></template>
-          <ng-template #LoggedIn>
-            <mat-list-item class="basic-flow">
-              <button mat-stroked-button color="primary" (click)="logout()">Logout</button>
-              <a mat-stroked-button color="primary" routerLink="/password/change">Change Password</a>
-            </mat-list-item>
-            <mat-list-item class="basic-flow">
-              <a mat-stroked-button color="primary" routerLink="/example">Token refresh example</a>
-            </mat-list-item>
-          </ng-template>
-          <ng-template #LoggedOut>
-            <mat-list-item class="basic-flow">
-              <a mat-stroked-button color="primary" routerLink="/login">Login</a>
-              <a mat-stroked-button color="primary" routerLink="/user/register">Sign up</a>
-            </mat-list-item>
-          </ng-template>
+        <template *ngIf="isLoggedIn; then LoggedIn; else LoggedOut"></template>
+        <ng-template #LoggedIn>
+          <mat-list-item class="basic-flow">
+            <button mat-stroked-button color="primary" (click)="logout()">
+              Logout
+            </button>
+            <a mat-stroked-button color="primary" routerLink="/password/change"
+              >Change Password</a
+            >
+          </mat-list-item>
+          <mat-list-item class="basic-flow">
+            <a mat-stroked-button color="primary" routerLink="/example"
+              >Token refresh example</a
+            >
+          </mat-list-item>
+        </ng-template>
+        <ng-template #LoggedOut>
+          <mat-list-item class="basic-flow">
+            <a mat-stroked-button color="primary" routerLink="/login">Login</a>
+            <a mat-stroked-button color="primary" routerLink="/user/register"
+              >Sign up</a
+            >
+          </mat-list-item>
+        </ng-template>
+      </mat-list>
+      <mat-divider></mat-divider>
+      <h4 mat-subheader>OAuth2 Flow</h4>
+      <mat-list>
+        <mat-list-item class="oauth2-flow">
+          <a
+            mat-stroked-button
+            color="primary"
+            href="http://localhost:3000/oauth2/authorize"
+            >Login</a
+          >
+        </mat-list-item>
       </mat-list>
       <mat-divider></mat-divider>
       <h4 mat-subheader>Quick Links</h4>
       <mat-nav-list dense class="scrollable">
         <a mat-list-item color="primary" routerLink="/login">Login</a>
         <a mat-list-item color="primary" routerLink="/login/two-factor/token">
-          <mat-icon matListIcon>subdirectory_arrow_right</mat-icon>Two Factor (with invalid token)
+          <mat-icon matListIcon>subdirectory_arrow_right</mat-icon>Two Factor
+          (with invalid token)
         </a>
         <a mat-list-item color="primary" routerLink="/password/forgot">
-          <mat-icon matListIcon>subdirectory_arrow_right</mat-icon>Forgot Password
+          <mat-icon matListIcon>subdirectory_arrow_right</mat-icon>Forgot
+          Password
         </a>
         <a mat-list-item color="primary" routerLink="/password/sent">
           <mat-icon matListIcon></mat-icon>
@@ -42,18 +64,30 @@
           <mat-icon matListIcon>arrow_right_alt</mat-icon>
           Reset Password (with invalid token)
         </a>
-        <a mat-list-item color="primary" [routerLink]="['/password/change-required/token']">
+        <a
+          mat-list-item
+          color="primary"
+          [routerLink]="['/password/change-required/token']"
+        >
           <mat-icon matListIcon>subdirectory_arrow_right</mat-icon>
           Change Password w/ change required message
         </a>
-        <a mat-list-item color="primary" [routerLink]="['/login', { showMessagePasswordChange: true }]">
+        <a
+          mat-list-item
+          color="primary"
+          [routerLink]="['/login', { showMessagePasswordChange: true }]"
+        >
           <mat-icon matListIcon></mat-icon>
           <mat-icon matListIcon>subdirectory_arrow_right</mat-icon>
           Login w/ password change message
         </a>
 
         <a mat-list-item color="primary" routerLink="/user/register">Sign Up</a>
-        <a mat-list-item color="primary" [routerLink]="['/login', { showMessageRegistration: true }]">
+        <a
+          mat-list-item
+          color="primary"
+          [routerLink]="['/login', { showMessageRegistration: true }]"
+        >
           <mat-icon matListIcon>subdirectory_arrow_right</mat-icon>
           Login w/ registration message
         </a>
@@ -75,14 +109,17 @@
           <mat-icon matListIcon>arrow_right_alt</mat-icon>
           Setup Password (with invalid token)
         </a>
-        <a mat-list-item color="primary" [routerLink]="['/login', { showMessagePasswordSetup: true }]">
+        <a
+          mat-list-item
+          color="primary"
+          [routerLink]="['/login', { showMessagePasswordSetup: true }]"
+        >
           <mat-icon matListIcon></mat-icon>
           <mat-icon matListIcon>subdirectory_arrow_right</mat-icon>
           Login w/ setup message
         </a>
       </mat-nav-list>
     </mat-card-content>
-    <mat-card-actions>
-    </mat-card-actions>
+    <mat-card-actions> </mat-card-actions>
   </mat-card>
 </div>

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -1,10 +1,10 @@
 export const environment = {
   production: false,
   fusionauth: {
-    apiUrl: 'http://localhost:9011',
-    applicationId: 'ad020c90-e0c8-4173-b914-d1409b9a5da9'
+    apiUrl: "http://localhost:9011",
+    applicationId: "bf499692-4847-440d-b46f-c264113890ea	"
   },
   angularExample: {
-    apiUrl: 'http://localhost:3000'
+    apiUrl: "http://localhost:3000"
   }
 };

--- a/server/config/config.json
+++ b/server/config/config.json
@@ -1,5 +1,8 @@
 {
-  "apiKey": "afQM46wknFeOLoglTmIhRuEUcl4nUugw0LasKpVCsDQ",
+  "apiKey": "ndRtGYERFHgcHhBqbjfMPuESRY7X_6vZ6fWm4WazUv0",
+  "callbackURL": "http://localhost:3000/oauth2/callback",
+  "clientID": "bf499692-4847-440d-b46f-c264113890ea",
+  "clientSecret": "duVtuVZvoXb7kxwj7E8T7c4i6GyBRKF4KLpFmgpHxi4",
   "host": "localhost",
   "port": "9011"
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -18,6 +18,11 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
     "body-parser": {
       "version": "1.18.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
@@ -254,6 +259,11 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -272,10 +282,60 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
+    "passport": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.0.tgz",
+      "integrity": "sha1-xQlWkTR71a07XhgCOMORTRbwWBE=",
+      "requires": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1"
+      }
+    },
+    "passport-oauth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth/-/passport-oauth-1.0.0.tgz",
+      "integrity": "sha1-kK/2M4dUDwIImvKM2tOep/gNd98=",
+      "requires": {
+        "passport-oauth1": "1.x.x",
+        "passport-oauth2": "1.x.x"
+      }
+    },
+    "passport-oauth1": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth1/-/passport-oauth1-1.1.0.tgz",
+      "integrity": "sha1-p96YiiEfnPRoc3cTDqdN8ycwyRg=",
+      "requires": {
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "utils-merge": "1.x.x"
+      }
+    },
+    "passport-oauth2": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.5.0.tgz",
+      "integrity": "sha512-kqBt6vR/5VlCK8iCx1/KpY42kQ+NEHZwsSyt4Y6STiNjU+wWICG1i8ucc1FapXDGO15C5O5VZz7+7vRzrDPXXQ==",
+      "requires": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "proxy-addr": {
       "version": "2.0.4",
@@ -366,6 +426,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
       }
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,8 @@
     "cookie-parser": "^1.4.4",
     "cors": "^2.8.5",
     "express": "^4.16.4",
-    "http": "0.0.0"
+    "http": "0.0.0",
+    "passport": "^0.4.0",
+    "passport-oauth": "^1.0.0"
   }
 }

--- a/server/routes/oauth2.js
+++ b/server/routes/oauth2.js
@@ -1,0 +1,82 @@
+const passport = require('passport');
+const OAuth2Strategy = require('passport-oauth').OAuth2Strategy;
+const http = require('http');
+const config = require('../config/config.json');
+
+passport.use(
+  'fusionauth',
+  new OAuth2Strategy(
+    {
+      authorizationURL: `${config.host}:${config.port}/oauth2/authorize`,
+      tokenURL: `${config.host}:${config.port}/oauth2/token`,
+      clientID: config.clientID,
+      clientSecret: config.clientSecret,
+      callbackURL: config.callbackURL
+    },
+    function(accessToken, refreshToken, profile, done) {
+      // verify accessToken was provided
+      if (!accessToken) {
+        done(null, false);
+      }
+
+      // verify token and get user info
+      const options = {
+        host: config.host,
+        port: config.port,
+        path: '/oauth2/userinfo',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`
+        }
+      };
+      const userInfoRequest = http.get(options, res => {
+        var chunks = '';
+        res.on('data', data => {
+          chunks += data;
+        });
+        res.on('end', () => {
+          if (res.statusCode === 200) {
+            const result = JSON.parse(chunks);
+            const user = {
+              ...result,
+              accessToken
+            };
+
+            // todo: persist user
+
+            done(null, user);
+          } else {
+            done(null, false);
+          }
+        });
+      });
+      userInfoRequest.end();
+    }
+  )
+);
+
+const callback = (req, res, next) => {
+  passport.authenticate('fusionauth', (err, user) => {
+    if (err) {
+      return next(err);
+    }
+    if (!user) {
+      return res.redirect('http://localhost:4200/login');
+    }
+    console.log(user);
+    res.cookie('accessToken', user.accessToken, { httpOnly: true });
+    res.redirect('http://localhost:4200');
+  })(req, res, next);
+};
+
+module.exports = {
+  authorize: passport.authenticate('fusionauth', {
+    session: false
+  }),
+  callback,
+  logout: (req, res) => {
+    req.logout();
+    res.redirect('http://localhost:4200/');
+  }
+};

--- a/server/server.js
+++ b/server/server.js
@@ -1,33 +1,40 @@
-const bodyParser = require("body-parser");
-const config = require('./config/config.json');
+const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
 const cors = require('cors');
 const express = require('express');
-const http = require('http');
-
+const passport = require('passport');
 
 const exampleApi = require('./routes/example-api');
 const registerUser = require('./routes/register-user');
 const fusionAuth = require('./routes/fusionauth');
+const oauth2 = require('./routes/oauth2');
 
 const app = express();
 const port = 3000;
 
-app.use(cors({
-  origin: 'http://localhost:4200',
-  credentials: true,
-  exposedHeaders: 'Access-Control-Allow-Origin,Access-Control-Allow-Credentials'
-}));
+app.use(
+  cors({
+    origin: 'http://localhost:4200',
+    credentials: true,
+    exposedHeaders:
+      'Access-Control-Allow-Origin,Access-Control-Allow-Credentials'
+  })
+);
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 app.use(cookieParser());
+app.use(passport.initialize());
 
 app.post('/api/user/registration', registerUser.registerUser);
 app.delete('/api/fusionauth/cookies', fusionAuth.deleteCookies);
 app.post('/api/fusionauth/cookies', fusionAuth.setCookies);
 app.get('/api/example', exampleApi.example);
 
-app.listen(port, (err) => {
+app.get('/oauth2/authorize', oauth2.authorize);
+app.get('/oauth2/callback', oauth2.callback);
+app.get('/oauth2/logout', oauth2.logout);
+
+app.listen(port, err => {
   if (err) {
     return console.log('something bad happened', err);
   }


### PR DESCRIPTION
- Added passport and passport-oauth dependencies to the express server.
- Created routes: /oauth2/authorize, /oauth2/callback and /oauth2/logout with implementations using Passport.
- Verified the token using the /oauth2/userinfo endpoint. Normally you would also persist the user data to your own DB. I left todo a comment in the code where that would go.
- Added a simple "Login" button to the Angular client to the authorize route on the server.